### PR TITLE
Octo 10241 prep and fork the beta 3 version of auditlog nicole tibay

### DIFF
--- a/auditlog/conf.py
+++ b/auditlog/conf.py
@@ -40,3 +40,6 @@ settings.AUDITLOG_TWO_STEP_MIGRATION = getattr(
 settings.AUDITLOG_USE_TEXT_CHANGES_IF_JSON_IS_NOT_PRESENT = getattr(
     settings, "AUDITLOG_USE_TEXT_CHANGES_IF_JSON_IS_NOT_PRESENT", False
 )
+
+# Custom
+settings.AUDITLOG_DISABLE_AUDITLOG = getattr(settings, "AUDITLOG", {}).get("disable_auditlog", False)

--- a/auditlog/migrations/0010_alter_logentry_timestamp.py
+++ b/auditlog/migrations/0010_alter_logentry_timestamp.py
@@ -9,11 +9,25 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AlterField(
-            model_name="logentry",
-            name="timestamp",
-            field=models.DateTimeField(
-                auto_now_add=True, db_index=True, verbose_name="timestamp"
-            ),
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(
+                sql="""
+                CREATE INDEX "auditlog_logentry_v2_timestamp_37867bb0" ON "auditlog_logentry" ("timestamp");
+                """,
+                reverse_sql="""
+                DROP INDEX CONCURRENTLY IF EXISTS "auditlog_logentry_v2_timestamp_37867bb0";
+                """
+                ),
+            ],
+            state_operations=[
+                migrations.AlterField(
+                    model_name="logentry",
+                    name="timestamp",
+                    field=models.DateTimeField(
+                        auto_now_add=True, db_index=True, verbose_name="timestamp"
+                    ),
+                ),
+            ],
         ),
     ]

--- a/auditlog/registry.py
+++ b/auditlog/registry.py
@@ -55,6 +55,9 @@ class AuditlogModelRegistry:
         self._signals = {}
         self._m2m_signals = defaultdict(dict)
 
+        if settings.AUDITLOG_DISABLE_AUDITLOG:
+            return
+
         if create:
             self._signals[post_save] = log_create
         if update:
@@ -194,6 +197,9 @@ class AuditlogModelRegistry:
         Connect signals for the model.
         """
         from auditlog.receivers import make_log_m2m_changes
+
+        if settings.AUDITLOG_DISABLE_AUDITLOG:
+            return
 
         for signal, receiver in self._signals.items():
             signal.connect(


### PR DESCRIPTION
Add some customisations:

1. Update migrations 0010 to rename already existing index `auditlog_logentry_timestamp_37867bb0`
2. Enable support for existing functionality of disabling auditlog application wide. Current configuration used:

```
AUDITLOG["disable_auditlog"] = False
```

3. Fix [open issue](https://github.com/jazzband/django-auditlog/issues/539) of logging all rows of M2M fields resulting to very slow performance.